### PR TITLE
Add BytesWritable class

### DIFF
--- a/python-hadoop/hadoop/io/BytesWritable.py
+++ b/python-hadoop/hadoop/io/BytesWritable.py
@@ -16,18 +16,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import OutputStream
-import InputStream
+from Writable import AbstractValueWritable
 
-import SequenceFile
-import ArrayFile
-import MapFile
-import SetFile
+class BytesWritable(AbstractValueWritable):
+    def write(self, data_output):
+        data_output.writeInt(len(self._value))
+        data_output.write(self._value)
 
-from Writable import *
-from IntWritable import *
-from BytesWritable import *
-from Text import *
-import WritableUtils
+    def readFields(self, data_input):
+        size = data_input.readInt()
+        self._value = data_input.readFully(size)
 
-import compress
+    def toString(self):
+        return ''.join(chr(x) for x in self._value)

--- a/python-hadoop/hadoop/io/InputStream.py
+++ b/python-hadoop/hadoop/io/InputStream.py
@@ -35,6 +35,9 @@ class InputStream(object):
     def readByte(self):
         return self.read(1)
 
+    def readFully(self, length):
+        return self.read(length)
+
     def read(self, length):
         raise NotImplementedError
 
@@ -139,6 +142,9 @@ class DataInputStream(InputStream):
     def readByte(self):
         data = self._stream.read(1)
         return struct.unpack(">b", data)[0]
+
+    def readFully(self, length):
+        return [self.readByte() for _ in xrange(length)]
 
     def readUByte(self):
         data = self._stream.read(1)


### PR DESCRIPTION
I needed this for reading sequence files written by [secor](https://github.com/pinterest/secor) and tried to follow the Java API as much as possible: http://grepcode.com/file/repo1.maven.org/maven2/com.ning/metrics.action/0.2.7/org/apache/hadoop/io/BytesWritable.java