### PR TITLE
filter our non-printable characters

### DIFF
--- a/python-hadoop/hadoop/io/BytesWritable.py
+++ b/python-hadoop/hadoop/io/BytesWritable.py
@@ -28,4 +28,4 @@ class BytesWritable(AbstractValueWritable):
         self._value = data_input.readFully(size)
 
     def toString(self):
-        return ''.join(chr(x) for x in self._value)
+        return ''.join(chr(x) for x in self._value if x > 31 or x == 9)

--- a/python-hadoop/hadoop/io/BytesWritable.py
+++ b/python-hadoop/hadoop/io/BytesWritable.py
@@ -28,4 +28,4 @@ class BytesWritable(AbstractValueWritable):
         self._value = data_input.readFully(size)
 
     def toString(self):
-        return ''.join(chr(x) for x in self._value if x > 31 or x == 9)
+        return ''.join(chr(x % 256) for x in self._value)


### PR DESCRIPTION
Small change to the BytesWritable toString method to filter out non-printable characters so that chr doesn't throw an exception
